### PR TITLE
add path_key config variable to be able to insert read file path into the event

### DIFF
--- a/lib/fluent/plugin/in_tail_ex.rb
+++ b/lib/fluent/plugin/in_tail_ex.rb
@@ -89,7 +89,7 @@ module Fluent
           line.chomp! # remove \n
           time, record = parse_line(line)
           if time && record
-            record[@path_key] = path unless @path_key.nil?
+            record[@path_key] ||= path unless @path_key.nil?
             es.add(time, record)
           else
             log.warn "pattern not match: #{line.inspect}"


### PR DESCRIPTION
When sending the events to the elasticsearch it''s quite useful to be able to understand what file is the origin of the received event. 
The patch add additional 'path_key' tag to the configuration, to hold the filename

```
<source>
  type tail_ex
  read_all false
  path_key path
  format none
  path /var/log/syslog
  tag syslog
</source>
```

All the changes are backward compatible as the path is inserted into the event only if path_key is specified.
